### PR TITLE
Options to bypass account health checks

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/AwsConfigurationProperties.groovy
@@ -50,10 +50,23 @@ class AwsConfigurationProperties {
     boolean changeSetsIncludeNestedStacks = false
   }
 
+  /**
+   * health check related config settings
+   */
+  @Canonical
+  static class HealthConfig {
+    /**
+     * flag to toggle verifying account health check. by default, account health check is enabled.
+     */
+    boolean verifyAccountHealth = true
+  }
+
   @NestedConfigurationProperty
   final ClientConfig client = new ClientConfig()
   @NestedConfigurationProperty
   final CleanupConfig cleanup = new CleanupConfig()
   @NestedConfigurationProperty
   final CloudFormationConfig cloudformation = new CloudFormationConfig()
+  @NestedConfigurationProperty
+  final HealthConfig health = new HealthConfig()
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/config/AwsConfiguration.groovy
@@ -158,11 +158,18 @@ class AwsConfiguration {
   }
 
   @Bean
+  AwsConfigurationProperties awsConfigurationProperties() {
+    return new AwsConfigurationProperties()
+  }
+
+  @Bean
   AmazonHealthIndicator amazonHealthIndicator(
     Registry registry,
     CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
-    AmazonClientProvider amazonClientProvider) {
-    return new AmazonHealthIndicator(registry, credentialsRepository, amazonClientProvider)
+    AmazonClientProvider amazonClientProvider,
+    AwsConfigurationProperties awsConfigurationProperties
+  ) {
+    return new AmazonHealthIndicator(registry, credentialsRepository, amazonClientProvider, awsConfigurationProperties)
   }
 
   public static class DeployDefaults {

--- a/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.java
+++ b/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/health/AmazonHealthIndicator.java
@@ -3,25 +3,31 @@ package com.netflix.spinnaker.clouddriver.aws.health;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.clouddriver.aws.AwsConfigurationProperties;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.core.AccountHealthIndicator;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class AmazonHealthIndicator extends AccountHealthIndicator<NetflixAmazonCredentials> {
 
   private static final String ID = "aws";
   private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
   private final AmazonClientProvider amazonClientProvider;
+  private final AwsConfigurationProperties awsConfigurationProperties;
 
   public AmazonHealthIndicator(
       Registry registry,
       CredentialsRepository<NetflixAmazonCredentials> credentialsRepository,
-      AmazonClientProvider amazonClientProvider) {
+      AmazonClientProvider amazonClientProvider,
+      AwsConfigurationProperties awsConfigurationProperties) {
     super(ID, registry);
     this.credentialsRepository = credentialsRepository;
     this.amazonClientProvider = amazonClientProvider;
+    this.awsConfigurationProperties = awsConfigurationProperties;
   }
 
   @Override
@@ -31,25 +37,32 @@ public class AmazonHealthIndicator extends AccountHealthIndicator<NetflixAmazonC
 
   @Override
   protected Optional<String> accountHealth(NetflixAmazonCredentials account) {
-    try {
-      AmazonEC2 ec2 =
-          amazonClientProvider.getAmazonEC2(account, AmazonClientProvider.DEFAULT_REGION, true);
-      if (ec2 == null) {
-        return Optional.of(
-            String.format("Could not create Amazon client for '%s'", account.getName()));
+    if (awsConfigurationProperties.getHealth().getVerifyAccountHealth()) {
+      log.info(
+          "aws.health.verifyAccountHealth flag is enabled - verifying connection to the EC2 accounts");
+      try {
+        AmazonEC2 ec2 =
+            amazonClientProvider.getAmazonEC2(account, AmazonClientProvider.DEFAULT_REGION, true);
+        if (ec2 == null) {
+          return Optional.of(
+              String.format("Could not create Amazon client for '%s'", account.getName()));
+        }
+
+        ec2.describeAccountAttributes();
+
+      } catch (AmazonServiceException e) {
+        String errorCode = e.getErrorCode();
+
+        if (!"RequestLimitExceeded".equalsIgnoreCase(errorCode)) {
+          return Optional.of(
+              String.format(
+                  "Failed to describe account attributes for '%s'. Message: '%s'",
+                  account.getName(), e.getMessage()));
+        }
       }
-
-      ec2.describeAccountAttributes();
-
-    } catch (AmazonServiceException e) {
-      String errorCode = e.getErrorCode();
-
-      if (!"RequestLimitExceeded".equalsIgnoreCase(errorCode)) {
-        return Optional.of(
-            String.format(
-                "Failed to describe account attributes for '%s'. Message: '%s'",
-                account.getName(), e.getMessage()));
-      }
+    } else {
+      log.info(
+          "aws.health.verifyAccountHealth flag is disabled - not verifying connection to the EC2 accounts");
     }
 
     return Optional.empty();

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/config/KubernetesConfigurationProperties.java
@@ -28,6 +28,9 @@ public class KubernetesConfigurationProperties {
   private static final int DEFAULT_CACHE_THREADS = 1;
   private List<ManagedAccount> accounts = new ArrayList<>();
 
+  /** flag to toggle account health check. Defaults to true. */
+  private boolean verifyAccountHealth = true;
+
   @Data
   public static class ManagedAccount implements CredentialsDefinition {
     private String name;

--- a/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesConfiguration.java
+++ b/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/config/KubernetesConfiguration.java
@@ -56,8 +56,10 @@ public class KubernetesConfiguration {
   @Bean
   public KubernetesHealthIndicator kubernetesHealthIndicator(
       Registry registry,
-      CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository) {
-    return new KubernetesHealthIndicator(registry, credentialsRepository);
+      CredentialsRepository<KubernetesNamedAccountCredentials> credentialsRepository,
+      KubernetesConfigurationProperties kubernetesConfigurationProperties) {
+    return new KubernetesHealthIndicator(
+        registry, credentialsRepository, kubernetesConfigurationProperties);
   }
 
   @Bean

--- a/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
+++ b/clouddriver-kubernetes/src/test/java/com/netflix/spinnaker/clouddriver/kubernetes/health/KubernetesHealthIndicatorTest.java
@@ -28,13 +28,17 @@ import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spinnaker.clouddriver.kubernetes.KubernetesCloudProvider;
 import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties;
+import com.netflix.spinnaker.clouddriver.kubernetes.config.KubernetesConfigurationProperties.ManagedAccount;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesNamedAccountCredentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.credentials.MapBackedCredentialsRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -54,6 +58,7 @@ final class KubernetesHealthIndicatorTest {
   private KubernetesNamedAccountCredentials healthyNamedCredentials;
   private KubernetesNamedAccountCredentials unhealthyNamedCredentialsFirst;
   private KubernetesNamedAccountCredentials unhealthyNamedCredentialsSecond;
+  private KubernetesConfigurationProperties kubernetesConfigurationProperties;
 
   @Mock private KubernetesCredentials.Factory healthyCredentialsFactory;
   @Mock private KubernetesCredentials.Factory unhealthyCredentialsFactory;
@@ -77,6 +82,8 @@ final class KubernetesHealthIndicatorTest {
     unhealthyNamedCredentialsSecond =
         new KubernetesNamedAccountCredentials(
             getManagedAccount(UNHEALTHY_ACCOUNT_NAME_SECOND), unhealthyCredentialsFactory);
+
+    kubernetesConfigurationProperties = new KubernetesConfigurationProperties();
   }
 
   @Test
@@ -84,7 +91,8 @@ final class KubernetesHealthIndicatorTest {
     CredentialsRepository<KubernetesNamedAccountCredentials> repository =
         stubCredentialsRepository(ImmutableList.of());
 
-    KubernetesHealthIndicator healthIndicator = new KubernetesHealthIndicator(REGISTRY, repository);
+    KubernetesHealthIndicator healthIndicator =
+        new KubernetesHealthIndicator(REGISTRY, repository, kubernetesConfigurationProperties);
 
     healthIndicator.checkHealth();
     Health result = healthIndicator.getHealth(true);
@@ -98,7 +106,8 @@ final class KubernetesHealthIndicatorTest {
     CredentialsRepository<KubernetesNamedAccountCredentials> repository =
         stubCredentialsRepository(ImmutableList.of(healthyNamedCredentials));
 
-    KubernetesHealthIndicator healthIndicator = new KubernetesHealthIndicator(REGISTRY, repository);
+    KubernetesHealthIndicator healthIndicator =
+        new KubernetesHealthIndicator(REGISTRY, repository, kubernetesConfigurationProperties);
 
     healthIndicator.checkHealth();
     Health result = healthIndicator.getHealth(true);
@@ -107,19 +116,27 @@ final class KubernetesHealthIndicatorTest {
     assertThat(result.getDetails()).isEmpty();
   }
 
-  @Test
-  void reportsErrorForUnhealthyAccount() {
+  @DisplayName(
+      "parameterized test to see how errors are reported based on the verifyAccountHealth flag")
+  @ParameterizedTest(name = "{index} => verifyAccountHealth = {0}")
+  @ValueSource(booleans = {true, false})
+  void reportsErrorForUnhealthyAccount(boolean verifyAccountHealth) {
     CredentialsRepository<KubernetesNamedAccountCredentials> repository =
         stubCredentialsRepository(ImmutableList.of(unhealthyNamedCredentialsFirst));
-
-    KubernetesHealthIndicator healthIndicator = new KubernetesHealthIndicator(REGISTRY, repository);
+    kubernetesConfigurationProperties.setVerifyAccountHealth(verifyAccountHealth);
+    KubernetesHealthIndicator healthIndicator =
+        new KubernetesHealthIndicator(REGISTRY, repository, kubernetesConfigurationProperties);
 
     healthIndicator.checkHealth();
     Health result = healthIndicator.getHealth(true);
 
     assertThat(result.getStatus()).isEqualTo(Status.UP);
-    assertThat(result.getDetails())
-        .containsOnly(entry(UNHEALTHY_ACCOUNT_NAME_FIRST, ERROR_MESSAGE));
+    if (verifyAccountHealth) {
+      assertThat(result.getDetails())
+          .containsOnly(entry(UNHEALTHY_ACCOUNT_NAME_FIRST, ERROR_MESSAGE));
+    } else {
+      assertThat(result.getDetails()).isEmpty();
+    }
   }
 
   @Test
@@ -131,7 +148,8 @@ final class KubernetesHealthIndicatorTest {
                 unhealthyNamedCredentialsFirst,
                 unhealthyNamedCredentialsSecond));
 
-    KubernetesHealthIndicator healthIndicator = new KubernetesHealthIndicator(REGISTRY, repository);
+    KubernetesHealthIndicator healthIndicator =
+        new KubernetesHealthIndicator(REGISTRY, repository, kubernetesConfigurationProperties);
 
     healthIndicator.checkHealth();
     Health result = healthIndicator.getHealth(true);
@@ -147,9 +165,8 @@ final class KubernetesHealthIndicatorTest {
             entry(UNHEALTHY_ACCOUNT_NAME_SECOND, ERROR_MESSAGE));
   }
 
-  private static KubernetesConfigurationProperties.ManagedAccount getManagedAccount(String name) {
-    KubernetesConfigurationProperties.ManagedAccount managedAccount =
-        new KubernetesConfigurationProperties.ManagedAccount();
+  private static ManagedAccount getManagedAccount(String name) {
+    ManagedAccount managedAccount = new ManagedAccount();
     managedAccount.setName(name);
     return managedAccount;
   }


### PR DESCRIPTION
cherry-picked commits to provide configurable options to bypass account health checks for kubernetes & aws accounts
