### PR TITLE
OP-20665 - Fix identical clone path issue

### DIFF
--- a/clouddriver-artifacts/src/integration/java/com/netflix/spinnaker/clouddriver/artifacts/GitRepoTest.java
+++ b/clouddriver-artifacts/src/integration/java/com/netflix/spinnaker/clouddriver/artifacts/GitRepoTest.java
@@ -403,7 +403,9 @@ public class GitRepoTest {
     Path localClone =
         new GitRepoFileSystem(new GitRepoArtifactProviderProperties())
             .getLocalClonePath(
-                (String) artifact.get("reference"), (String) artifact.get("version"));
+                (String) artifact.get("reference"),
+                (String) artifact.get("version"),
+                "pathDistinguisher");
     if (localClone.toFile().exists()) {
       FileUtils.forceDelete(localClone.toFile());
     }

--- a/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoFileSystem.java
+++ b/clouddriver-artifacts/src/main/java/com/netflix/spinnaker/clouddriver/artifacts/gitRepo/GitRepoFileSystem.java
@@ -45,16 +45,17 @@ public class GitRepoFileSystem {
     this.config = properties;
   }
 
-  public Path getLocalClonePath(String repoUrl, String branch) {
-    return Paths.get(CLONES_HOME.toString(), hashCoordinates(repoUrl, branch));
+  public Path getLocalClonePath(String repoUrl, String branch, String pathDistinguisher) {
+    return Paths.get(CLONES_HOME.toString(), hashCoordinates(repoUrl, branch, pathDistinguisher));
   }
 
   public int getCloneWaitLockTimeoutSec() {
     return config.getCloneWaitLockTimeoutSec();
   }
 
-  public boolean tryTimedLock(String repoUrl, String branch) throws InterruptedException {
-    String hash = hashCoordinates(repoUrl, branch);
+  public boolean tryTimedLock(String repoUrl, String branch, String pathDistinguisher)
+      throws InterruptedException {
+    String hash = hashCoordinates(repoUrl, branch, pathDistinguisher);
 
     log.debug(
         "Trying filesystem timed lock for {} (branch {}), hash: {} for {} seconds",
@@ -91,8 +92,8 @@ public class GitRepoFileSystem {
     return locked;
   }
 
-  public void unlock(String repoUrl, String branch) {
-    String hash = hashCoordinates(repoUrl, branch);
+  public void unlock(String repoUrl, String branch, String pathDistinguisher) {
+    String hash = hashCoordinates(repoUrl, branch, pathDistinguisher);
     log.debug("Unlocking filesystem for {} (branch {}), hash: {}", repoUrl, branch, hash);
     unlock(hash);
   }
@@ -120,12 +121,13 @@ public class GitRepoFileSystem {
     return currentSize >= 0 && currentSize < config.getCloneRetentionMaxBytes();
   }
 
-  private String hashCoordinates(String repoUrl, String branch) {
+  private String hashCoordinates(String repoUrl, String branch, String pathDistinguisher) {
     String coordinates =
         String.format(
-            "%s-%s",
+            "%s-%s-%s",
             Optional.ofNullable(repoUrl).orElse("unknownUrl"),
-            Optional.ofNullable(branch).orElse("defaultBranch"));
+            Optional.ofNullable(branch).orElse("defaultBranch"),
+            Optional.ofNullable(pathDistinguisher).orElse("pathDistinguisher"));
     return Hashing.sha256().hashString(coordinates, Charset.defaultCharset()).toString();
   }
 

--- a/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AbstractAtomicOperationsCredentialsConverter.java
+++ b/clouddriver-core/src/main/java/com/netflix/spinnaker/clouddriver/security/AbstractAtomicOperationsCredentialsConverter.java
@@ -24,9 +24,10 @@ import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationConverter;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException;
 import java.util.stream.Collectors;
-import javax.validation.constraints.NotNull;
+// import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class AbstractAtomicOperationsCredentialsConverter<T extends AccountCredentials<?>>

--- a/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
+++ b/clouddriver-web/src/main/java/com/netflix/spinnaker/clouddriver/controllers/ArtifactController.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +60,11 @@ public class ArtifactController {
 
   // PUT because we need to send a body, which GET does not allow for spring/retrofit
   @RequestMapping(method = RequestMethod.PUT, value = "/fetch")
-  StreamingResponseBody fetch(@RequestBody Artifact artifact) {
+  StreamingResponseBody fetch(HttpServletRequest request, @RequestBody Artifact artifact) {
+    log.info(
+        "\n \n ********* request JSESSIONID={}, artifact subPath: {}",
+        request.getSession().getId(),
+        artifact.getLocation());
     if (artifact != null && artifact.getType().equals("front50/pipelineTemplate")) {
       log.info("**** Fetching pipelineTemplate : {}", artifact.getReference());
     }


### PR DESCRIPTION
When the git repo and the branch are same for multiple /artifacts/fetch requests, the generated local clone path for them are identical. This PR makes them distinct and hence hopefully fixes the jumbled up responses in Rosco.  