### PR TITLE
Configured ThreadPoolTaskExecutor

### DIFF
--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/WebConfig.groovy
@@ -18,12 +18,13 @@ package com.netflix.spinnaker.clouddriver
 
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.clouddriver.configuration.CredentialsConfiguration
-
+import com.netflix.spinnaker.clouddriver.configuration.ThreadPoolTaskExecutorConfiguration
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueue
 import com.netflix.spinnaker.clouddriver.requestqueue.RequestQueueConfiguration
 import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean
@@ -34,9 +35,11 @@ import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.filter.ShallowEtagHeaderFilter
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
@@ -44,6 +47,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 import javax.servlet.Filter
 import javax.servlet.http.HttpServletResponse
 
+@Slf4j
 @Configuration
 @ComponentScan([
   'com.netflix.spinnaker.clouddriver.controllers',
@@ -51,10 +55,13 @@ import javax.servlet.http.HttpServletResponse
   'com.netflix.spinnaker.clouddriver.listeners',
   'com.netflix.spinnaker.clouddriver.security',
 ])
-@EnableConfigurationProperties([CredentialsConfiguration, RequestQueueConfiguration])
+@EnableConfigurationProperties([CredentialsConfiguration, RequestQueueConfiguration, ThreadPoolTaskExecutorConfiguration])
 public class WebConfig extends WebMvcConfigurerAdapter {
   @Autowired
   Registry registry
+
+  @Autowired
+  ThreadPoolTaskExecutorConfiguration threadPoolTaskExecutorConfiguration
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
@@ -90,5 +97,19 @@ public class WebConfig extends WebMvcConfigurerAdapter {
       .defaultContentType(MediaType.APPLICATION_JSON_UTF8)
       .favorPathExtension(false)
       .ignoreAcceptHeader(true)
+  }
+
+  @Override
+  void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+    log.info("corePoolSize: {}", threadPoolTaskExecutorConfiguration.corePoolSize)
+    log.info("maxPoolSize: {}", threadPoolTaskExecutorConfiguration.maxPoolSize)
+    log.info("queueCapacity: {}", threadPoolTaskExecutorConfiguration.queueCapacity)
+    final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(threadPoolTaskExecutorConfiguration.corePoolSize);
+    executor.setMaxPoolSize(threadPoolTaskExecutorConfiguration.maxPoolSize);
+    executor.setQueueCapacity(threadPoolTaskExecutorConfiguration.queueCapacity)
+    executor.setThreadNamePrefix("thread-pool-task-executor-");
+    executor.initialize();
+    configurer.setTaskExecutor(executor);
   }
 }

--- a/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/configuration/ThreadPoolTaskExecutorConfiguration.groovy
+++ b/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/configuration/ThreadPoolTaskExecutorConfiguration.groovy
@@ -1,0 +1,14 @@
+package com.netflix.spinnaker.clouddriver.configuration
+
+import groovy.transform.Canonical
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@Canonical
+@ConfigurationProperties('thread-pool-executor')
+class ThreadPoolTaskExecutorConfiguration {
+  Integer corePoolSize = 10
+  Integer maxPoolSize = 50
+  Integer queueCapacity = 300
+}


### PR DESCRIPTION
Configured ThreadPoolTaskExecutor to overcome the limitations of using SimpleAsyncTaskExecutor. We get to see the following warming message in logs when `/artifacts/fetch` async call is invoked for the first time.

```
!!!
An Executor is required to handle java.util.concurrent.Callable return values.
Please, configure a TaskExecutor in the MVC config under "async support".
The SimpleAsyncTaskExecutor currently in use is not suitable under load.
-------------------------------
Request URI: '/artifacts/fetch/'
!!!
```

Made the following fields configurable to allow fine tuning the performance. 

```yaml
thread-pool-executor:
  corePoolSize: 10
  maxPoolSize: 50
  queueCapacity: 300
```